### PR TITLE
fix: linebreak soft wrap

### DIFF
--- a/backend/src/logic/svgRenderer.ts
+++ b/backend/src/logic/svgRenderer.ts
@@ -19,7 +19,7 @@ const DEFAULT_CONFIG: Partial<RendererOptions> = {
 };
 
 const generateLineNumber = (idx: number, { fg, fontWidth }: Partial<RendererOptions> & { lineHeight: number }) => {
-  return `<tspan fill="${fg}" fill-opacity="0.25" x="-${(fontWidth as number) * 4}">${String(idx + 1).padStart(
+  return `<tspan fill="${fg}" fill-opacity="0.25" x="-${(fontWidth as number) * 4}">${String(idx).padStart(
     3,
     '\u2800',
   )}</tspan>`;
@@ -116,20 +116,18 @@ export function svgRenderer(options: RendererOptions): {
       svg += `<g id="tokens" transform="translate(${lineNumberWidth}, ${titlebarHeight})">`;
 
       lines.forEach((line, index) => {
+        const idx = index + 1;
+
         if (line.length === 0) {
           if (lineNumber) {
-            svg += `<text font-family="${fontFamily}" font-size="${fontSize}" y="${
-              lineHeight * (index + 1 + offsetY)
-            }">\n`;
-            svg += generateLineNumber(index, { fontFamily, fontWidth, lineHeight, fg });
+            svg += `<text font-family="${fontFamily}" font-size="${fontSize}" y="${lineHeight * (idx + offsetY)}">\n`;
+            svg += generateLineNumber(idx, { fontFamily, fontWidth, lineHeight, fg });
             svg += '</text>';
           }
           svg += `\n`;
         } else {
-          svg += `<text font-family="${fontFamily}" font-size="${fontSize}" y="${
-            lineHeight * (index + 1 + offsetY)
-          }">\n`;
-          if (lineNumber) svg += generateLineNumber(index, { fontFamily, fontWidth, lineHeight, fg });
+          svg += `<text font-family="${fontFamily}" font-size="${fontSize}" y="${lineHeight * (idx + offsetY)}">\n`;
+          if (lineNumber) svg += generateLineNumber(idx, { fontFamily, fontWidth, lineHeight, fg });
 
           let indent = 0;
           line.forEach((token) => {

--- a/backend/src/logic/svgRenderer.ts
+++ b/backend/src/logic/svgRenderer.ts
@@ -88,17 +88,17 @@ export function svgRenderer(options: RendererOptions): {
       const titlebarHeight = 32;
 
       // longest line + left/right 4 char width
-      const bgWidth = (longestLineTextLength + 4) * fontWidth + lineNumberWidth;
+      // const bgWidth = (longestLineTextLength + 4) * fontWidth + lineNumberWidth;
 
       // all rows + 2 rows top/bot
       // const bgHeight = (lines.length + verticalPadding * 2) * lineheight;
-      const bgHeight = (lines.length + 1) * lineHeight + titlebarHeight;
+      // const bgHeight = (lines.length + 1) * lineHeight + titlebarHeight;
 
       // to enable soft wrapping, set maxLineWidth to a positive integer (say 40)
       // and uncomment the 2 lines below it to adjust the svg size
-      const maxLineWidth = null; // characters, coming from request
-      // const bgWidth = (maxLineWidth + 4) * fontWidth + lineNumberWidth
-      // const bgHeight = (lines.length + 1) * lineHeight + titlebarHeight + 100; // 100 is arbitrary number
+      const maxLineWidth = 60; // characters, coming from request
+      const bgWidth = (maxLineWidth + 4) * fontWidth + lineNumberWidth;
+      const bgHeight = (lines.length + 1) * lineHeight + titlebarHeight + 100; // 100 is arbitrary number
 
       let offsetY = 0; // account for wrapped lines
 

--- a/backend/src/logic/svgRenderer.ts
+++ b/backend/src/logic/svgRenderer.ts
@@ -88,17 +88,17 @@ export function svgRenderer(options: RendererOptions): {
       const titlebarHeight = 32;
 
       // longest line + left/right 4 char width
-      // const bgWidth = (longestLineTextLength + 4) * fontWidth + lineNumberWidth;
+      const bgWidth = (longestLineTextLength + 4) * fontWidth + lineNumberWidth;
 
       // all rows + 2 rows top/bot
       // const bgHeight = (lines.length + verticalPadding * 2) * lineheight;
-      // const bgHeight = (lines.length + 1) * lineHeight + titlebarHeight;
+      const bgHeight = (lines.length + 1) * lineHeight + titlebarHeight;
 
       // to enable soft wrapping, set maxLineWidth to a positive integer (say 40)
       // and uncomment the 2 lines below it to adjust the svg size
-      const maxLineWidth = 60; // characters, coming from request
-      const bgWidth = (maxLineWidth + 4) * fontWidth + lineNumberWidth;
-      const bgHeight = (lines.length + 1) * lineHeight + titlebarHeight + 100; // 100 is arbitrary number
+      const maxLineWidth = null; // characters, coming from request
+      // const bgWidth = (maxLineWidth + 4) * fontWidth + lineNumberWidth;
+      // const bgHeight = (lines.length + 1) * lineHeight + titlebarHeight + 100; // 100 is arbitrary number
 
       let offsetY = 0; // account for wrapped lines
 
@@ -134,16 +134,11 @@ export function svgRenderer(options: RendererOptions): {
           let indent = 0;
           line.forEach((token) => {
             const tokenAttributes = getTokenSVGAttributes(token);
-            /**
-             * SVG rendering in Sketch/Affinity Photos: `<tspan>` with leading whitespace will render without whitespace
-             * Need to manually offset `x`
-             */
-
-            let tokenBreakIndex = Infinity;
 
             // chunk excess tokens to be rendered below
             const wrappedTokens: string[] = [];
-            let lastWrappedTokenIndex = 0;
+            let tokenBreakIndex = Infinity;
+            let lastWrappedTokenIndex = 0; // so next token know where to continue
 
             if (maxLineWidth !== null && indent + token.content.length > maxLineWidth) {
               tokenBreakIndex = maxLineWidth - indent;
@@ -162,6 +157,10 @@ export function svgRenderer(options: RendererOptions): {
               offsetY += wrappedTokens.length - 1;
             }
 
+            /**
+             * SVG rendering in Sketch/Affinity Photos: `<tspan>` with leading whitespace will render without whitespace
+             * Need to manually offset `x`
+             */
             if (token.content.startsWith(' ') && token.content.search(/\S/) !== -1) {
               const firstNonWhitespaceIndex = token.content.search(/\S/);
 


### PR DESCRIPTION
Add soft wrapping for issue [#34](https://github.com/teknologi-umum/graphene/issues/34)
Basic idea: if the token exceeds `maxLineWidth`, cut it and put the remaining into chunks to be rendered below the main line.
No line number. Highlighting is preserved.

@elianiva sementara maxLineWidth dan width/height (<- ini dari request kan nanti) dicomment

Baru coba untuk JavaScript aja

Not wrapped
![not-wrapped](https://i.imgur.com/cqLWLmZ.jpg)

Wrapped `maxLineWidth = 40`
![wrapped](https://i.imgur.com/LogF4M8.jpg)