### PR TITLE
add node user + build optimisation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,20 @@
 FROM node:16.14.0-bullseye
 
+USER node
+
+RUN mkdir -p /home/node
+
 WORKDIR /home/node/tmp
 
 COPY fonts/ /usr/local/share/fonts/
 
 WORKDIR /home/node/app
 
-COPY . .
+COPY --chown=node:node package.json .
 
 RUN npm install --workspaces
+
+COPY --chown=node:node . .
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
might resolve #114 

- trying a fix to the failing CD - looks like the docker build does not have permission.
- build optimisation by installing package.json before src files
